### PR TITLE
Split the plugins

### DIFF
--- a/components/mutagen-reqtificator/Reqtificator/GameContext.cs
+++ b/components/mutagen-reqtificator/Reqtificator/GameContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using Mutagen.Bethesda;
@@ -9,17 +10,20 @@ namespace Reqtificator
 {
     public record GameContext(ImmutableList<ILoadOrderListingGetter> ActiveMods, string DataFolder, GameRelease Release)
     {
-        public static bool IsAvailable(GameRelease release)
-        {
-            return PluginListings.TryGetListingsFile(release, out _);
-        }
-
-        public static GameContext GetRequiemContext(GameRelease release, ModKey patchToBeGenerated)
+        public static GameContext GetRequiemContext(GameRelease release, Collection<ModKeyStruct> patchesToBeGenerated)
         {
             string dataFolder = Directory.GetCurrentDirectory();
+            if (!PluginListings.TryGetListingsFile(release, out var path))
+            {
+                throw new FileNotFoundException("Could not locate load order automatically.");
+            }
+
+            var modKeys = new Collection<ModKey>();
+            foreach (var modKey in patchesToBeGenerated)
+                modKeys.Add(modKey.PluginKey);
 
             var loadOrderEntries = LoadOrder.GetLoadOrderListings(release, dataFolder, true);
-            var activeMods = loadOrderEntries.OnlyEnabled().TakeWhile(it => it.ModKey != patchToBeGenerated)
+            var activeMods = loadOrderEntries.OnlyEnabled().TakeWhile(it => !modKeys.Contains(it.ModKey))
                 .ToImmutableList();
 
             return new GameContext(activeMods, dataFolder, release);

--- a/components/mutagen-reqtificator/Reqtificator/Utils/Formatter.cs
+++ b/components/mutagen-reqtificator/Reqtificator/Utils/Formatter.cs
@@ -9,9 +9,13 @@ namespace Reqtificator.Utils
     {
         public static string FormatMultiline(string multiLineString, params string[] args)
         {
-            if (string.IsNullOrEmpty(multiLineString) || !multiLineString.StartsWith(Environment.NewLine, StringComparison.InvariantCulture))
+            if (string.IsNullOrEmpty(multiLineString))
             {
                 throw new FormatException("String must not be empty and must start with a NewLine character.");
+            }
+            if (!multiLineString.StartsWith(Environment.NewLine, StringComparison.InvariantCulture))
+            {
+                multiLineString = Environment.NewLine + multiLineString;
             }
 
             int indentationSize = multiLineString.Skip(Environment.NewLine.Length)


### PR DESCRIPTION
I split the patcher into 4 plugins, should be possible to split even more, if I add another field to the Enum and then assign the records in MainLogicExtension. The setup validation in papyrus will also need to be changed if more patches are split though.

I might be using an older source code because the backend is different. Sorry if I am my cloning got messed up the first time.