### PR TITLE
Master limit experiment

### DIFF
--- a/components/mutagen-reqtificator/Reqtificator/Backend.cs
+++ b/components/mutagen-reqtificator/Reqtificator/Backend.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Resources;
@@ -32,9 +34,23 @@ namespace System.Runtime.CompilerServices
 
 namespace Reqtificator
 {
+    public enum PluginGroup { Main, Actors, Levelled, Equipment }
+    public record ModKeyStruct
+    {
+        public PluginGroup Plugin { get; private set; }
+        public ModKey PluginKey { get; private set; }
+
+        public ModKeyStruct(PluginGroup plugin)
+        {
+            Plugin = plugin;
+            string pluginName = "Requiem for the Indifferent " + plugin.ToString() + ".esp";
+            PluginKey = ModKey.FromNameAndExtension(pluginName);
+        }
+    }
+
     internal class Backend
     {
-        private static readonly ModKey PatchModKey = ModKey.FromNameAndExtension("Requiem for the Indifferent.esp");
+        private static readonly Collection<ModKeyStruct> ModKeys = new();
         private static readonly ModKey RequiemModKey = new("Requiem", ModType.Plugin);
 
         private readonly GameRelease _release;
@@ -61,6 +77,11 @@ namespace Reqtificator
                 _release = GameContext.IsAvailable(GameRelease.SkyrimSEGog) ? GameRelease.SkyrimSEGog : GameRelease.SkyrimSE;
             }
 
+            foreach (PluginGroup value in Enum.GetValues(typeof(PluginGroup)))
+            {
+                ModKeys.Add(new ModKeyStruct(value));
+            }
+
             var buildInfo = HoconConfigurationFactory.FromResource<Backend>("VersionInfo");
             _version = new RequiemVersion(buildInfo.GetInt("versionNumber"), buildInfo.GetString("versionName"));
             Log.Information($"working directory: {Directory.GetCurrentDirectory()}");
@@ -68,7 +89,7 @@ namespace Reqtificator
             Log.Information($"build git branch: {buildInfo.GetString("gitBranch")}");
             Log.Information($"build git revision: {buildInfo.GetString("gitRevision")}");
 
-            _context = GameContext.GetRequiemContext(_release, PatchModKey);
+            _context = GameContext.GetRequiemContext(_release, ModKeys);
 
             Log.Information("load order:");
             _context.ActiveMods.WithIndex().ForEach(m => Log.Information($"  {m.Index} - {m.Item.ModKey}"));
@@ -121,20 +142,30 @@ namespace Reqtificator
                 var logLevel = updatedSettings.VerboseLogging ? LogEventLevel.Debug : LogEventLevel.Information;
                 _logs.LogLevel.MinimumLevel = logLevel;
                 updatedSettings.WriteToFile(Path.Combine(_context.DataFolder, "Reqtificator", "UserSettings.json"));
-                var generatedPatch = GeneratePatch(loadOrder, updatedSettings, PatchModKey);
+                var generatedPatches = GeneratePatch(loadOrder, updatedSettings);
                 Log.Information("done patching, now exporting to disk");
 
                 _events.PublishState(ReqtificatorState.Patching(90, "Saving Patch"));
-                var outcome = WritePatchToDisk(generatedPatch, _context.DataFolder, loadOrder);
-                if (outcome is null)
+                for (int i = 0; i < generatedPatches.Count; i++)
                 {
-                    Log.Information("done exporting");
-                    _events.PublishState(ReqtificatorState.Stopped(ReqtificatorOutcome.Success));
-                }
-                else
-                {
-                    Log.Information("exporting failed");
-                    _events.PublishState(ReqtificatorState.Stopped(outcome));
+                    var mod = generatedPatches[i];
+                    var outcome = WritePatchToDisk(mod, _context.DataFolder, loadOrder);
+                    if (outcome is null)
+                    {
+                        Log.Information("Exporting patch " + mod.ModKey.Name);
+                        if (i + 1 == generatedPatches.Count)
+                        {
+                            Log.Information("done exporting");
+                            _events.PublishState(ReqtificatorState.Stopped(ReqtificatorOutcome.Success));
+                            break;
+                        }
+                        continue;
+                    }
+                    else
+                    {
+                        Log.Information("exporting failed");
+                        _events.PublishState(ReqtificatorState.Stopped(outcome));
+                    }
                 }
             }
             catch (Exception ex)
@@ -167,14 +198,27 @@ namespace Reqtificator
         }
 
 
-        public SkyrimMod GeneratePatch(ILoadOrder<IModListing<ISkyrimModGetter>> loadOrder, UserSettings userConfig, ModKey patchModKey)
+        public List<SkyrimMod> GeneratePatch(ILoadOrder<IModListing<ISkyrimModGetter>> loadOrder, UserSettings userConfig)
+        {
+            var result = new List<SkyrimMod>();
+            var plugins = _executor.GeneratePatch(loadOrder, userConfig, ModKeys);
+
+            foreach (var plugin in plugins)
+            {
+                result.Add(ErrorCheck(plugin));
+            }
+
+            return result;
+        }
+
+        private SkyrimMod ErrorCheck(ErrorOr<SkyrimMod> error)
         {
             try
             {
 
                 Log.Information("start patching");
 
-                return _executor.GeneratePatch(loadOrder, userConfig, patchModKey) switch
+                return error switch
                 {
                     Success<SkyrimMod> s => s.Value,
                     Failed<SkyrimMod> f => throw f.Error,

--- a/components/mutagen-reqtificator/Reqtificator/GameContext.cs
+++ b/components/mutagen-reqtificator/Reqtificator/GameContext.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Immutable;
+﻿using System;
+using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using Mutagen.Bethesda;
@@ -14,12 +16,22 @@ namespace Reqtificator
             return PluginListings.TryGetListingsFile(release, out _);
         }
 
-        public static GameContext GetRequiemContext(GameRelease release, ModKey patchToBeGenerated)
+        public static GameContext GetRequiemContext(GameRelease release, Collection<ModKeyStruct> patchesToBeGenerated)
         {
+            if (patchesToBeGenerated == null)
+            {
+                throw new ArgumentNullException(nameof(patchesToBeGenerated));
+            }
             string dataFolder = Directory.GetCurrentDirectory();
 
+            var modKeys = new Collection<ModKey>();
+            foreach (var modKey in patchesToBeGenerated)
+            {
+                modKeys.Add(modKey.PluginKey);
+            }
+
             var loadOrderEntries = LoadOrder.GetLoadOrderListings(release, dataFolder, true);
-            var activeMods = loadOrderEntries.OnlyEnabled().TakeWhile(it => it.ModKey != patchToBeGenerated)
+            var activeMods = loadOrderEntries.OnlyEnabled().TakeWhile(it => !modKeys.Contains(it.ModKey))
                 .ToImmutableList();
 
             return new GameContext(activeMods, dataFolder, release);

--- a/components/mutagen-reqtificator/Reqtificator/MainLogicExecutor.cs
+++ b/components/mutagen-reqtificator/Reqtificator/MainLogicExecutor.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Collections.ObjectModel;
 using System.Linq;
+using DynamicData;
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Plugins;
 using Mutagen.Bethesda.Plugins.Allocators;
@@ -47,8 +50,8 @@ namespace Reqtificator
             _version = version;
         }
 
-        public ErrorOr<SkyrimMod> GeneratePatch(ILoadOrder<IModListing<ISkyrimModGetter>> loadOrder,
-            UserSettings userSettings, ModKey outputModKey)
+        public List<ErrorOr<SkyrimMod>> GeneratePatch(ILoadOrder<IModListing<ISkyrimModGetter>> loadOrder,
+            UserSettings userSettings, Collection<ModKeyStruct> outputModKeys)
         {
             _events.PublishState(ReqtificatorState.Patching(0.0, ""));
 
@@ -75,7 +78,10 @@ namespace Reqtificator
                 .Select(ml => ml.ModKey)
                 .ToImmutableHashSet();
 
-            var (generatedPatch, formAllocator) = CreatePatchBaseMod(outputModKey, _version, importedModsLinkCache);
+            var (generatedPatch, formAllocator) = CreatePatchBaseMod(PluginGroup.Main, outputModKeys, _version, importedModsLinkCache);
+            var (generatedPatchActors, formAllocatorActors) = CreatePatchBaseMod(PluginGroup.Actors, outputModKeys, _version, importedModsLinkCache);
+            var (generatedPatchLevelled, formAllocatorLevelled) = CreatePatchBaseMod(PluginGroup.Levelled, outputModKeys, _version, importedModsLinkCache);
+            var (generatedPatchEquipment, formAllocatorEquipment) = CreatePatchBaseMod(PluginGroup.Equipment, outputModKeys, _version, importedModsLinkCache);
 
             _events.PublishState(ReqtificatorState.Patching(5, "Ammo"));
             var ammoPatched = PatchAmmunition(loadOrder);
@@ -113,32 +119,58 @@ namespace Reqtificator
 
             _events.PublishState(ReqtificatorState.Patching(55, "Actor Variations"));
             var actorVariationsPatched =
-                actorsPatched.Map(actors => PatchActorVariations(loadOrder, actors, modsWithActorVariations, generatedPatch));
+                actorsPatched.Map(actors => PatchActorVariations(loadOrder, actors, modsWithActorVariations, generatedPatchActors));
 
             Log.Information("adding patched records to output mod");
 
             _events.PublishState(ReqtificatorState.Patching(75, "Generating Patch"));
-            var fullPatch = generatedPatch.AsSuccess()
-                .Map(m => m.WithRecords(encounterZonesPatched))
+
+            var mainPatch = generatedPatch.AsSuccess()
                 .Map(m => m.WithRecords(doorsPatched))
-                .Map(m => m.WithRecords(containersPatched))
-                .Map(m => m.WithRecords(leveledItemsPatched))
-                .Map(m => m.WithRecords(leveledCharactersPatched))
-                .FlatMap(m => armorsPatched.Map(m.WithRecords))
-                .Map(m => m.WithRecords(ammoPatched))
-                .FlatMap(m => weaponsPatched.Map(m.WithRecords))
+                .Map(m => m.WithRecords(containersPatched));
+
+            var actorPatch = generatedPatchActors.AsSuccess()
                 .FlatMap(m => actorsPatched.Map(m.WithRecords))
                 .FlatMap(m => actorVariationsPatched.Map(m.WithRecords))
                 .Map(m => m.WithRecords(racesPatched));
 
+            var levelledPatch = generatedPatchLevelled.AsSuccess()
+                .Map(m => m.WithRecords(encounterZonesPatched))
+                .Map(m => m.WithRecords(leveledItemsPatched))
+                .Map(m => m.WithRecords(leveledCharactersPatched));
+
+            var equipmentPatch = generatedPatchEquipment.AsSuccess()
+                .FlatMap(m => armorsPatched.Map(m.WithRecords))
+                .Map(m => m.WithRecords(ammoPatched))
+                .FlatMap(m => weaponsPatched.Map(m.WithRecords));
+
             formAllocator.Commit();
-            return fullPatch;
+            formAllocatorActors.Commit();
+            formAllocatorLevelled.Commit();
+            formAllocatorEquipment.Commit();
+
+            return new List<ErrorOr<SkyrimMod>>
+            {
+                mainPatch,
+                actorPatch,
+                levelledPatch,
+                equipmentPatch
+            }; ;
         }
 
-        private static (SkyrimMod, TextFileFormKeyAllocator) CreatePatchBaseMod(ModKey outputModKey,
+        private static (SkyrimMod, TextFileFormKeyAllocator) CreatePatchBaseMod(PluginGroup pluginReference, Collection<ModKeyStruct> outputModKeys,
             RequiemVersion version,
             ImmutableLoadOrderLinkCache<ISkyrimMod, ISkyrimModGetter> cache)
         {
+            var outputModKey = ModKey.FromNameAndExtension("If you're seeing this ERROR.esp");
+            foreach (var modKey in outputModKeys)
+            {
+                if (modKey.Plugin == pluginReference)
+                {
+                    outputModKey = modKey.PluginKey;
+                }
+            }
+
             var patch = new SkyrimMod(outputModKey, SkyrimRelease.SkyrimSE)
             {
                 ModHeader =


### PR DESCRIPTION
This PoC splits the generated patch into four plugins. In a minimal load order this reduces the number of master files from 78 to 64, which corresponds to ~20% increase in allowed plugins.