### PR TITLE
Update REQ_AttributeSystem.psc: optimise attribute bonus calculation

### DIFF
--- a/components/papyrus-scripts/src/gamemechanics/coreScripts/REQ_AttributeSystem.psc
+++ b/components/papyrus-scripts/src/gamemechanics/coreScripts/REQ_AttributeSystem.psc
@@ -60,11 +60,13 @@ Function initScript(Int currentVersion, Int nevVersion)
 	RegisterForMenu("MagicMenu")
 EndFunction
 
+Event OnLevelUp()
+	; bonuses are based on Base Actor Values, these only change on level up.
+	UpdateAttributeBonuses()
+EndEvent
+
 Event OnMenuClose(String Menu)
 	GoToState("working")
-	If Menu != "MagicMenu"
-		UpdateAttributeBonuses()
-	EndIf
 	UpdateShoutBonuses()
 	GoToState("")
 	If doagain


### PR DESCRIPTION
The attribute bonuses are based on player base values; these can only change upon level up. Instead of recalculating the bonuses every time the menu opens, do it when the player levels up.